### PR TITLE
show fonts using HTTP or HTTPS depending on parent page

### DIFF
--- a/src/main/resources/webapp/index.html
+++ b/src/main/resources/webapp/index.html
@@ -14,7 +14,7 @@
     <script src="js/confirmEmailCtrl.js"></script>
     <script src="js/listWorkshopCtrl.js"></script>
 
-    <link href="http://fonts.googleapis.com/css?family=Source+Sans+Pro:200,300,400,700,900" rel="stylesheet" type="text/css">
+    <link href="//fonts.googleapis.com/css?family=Source+Sans+Pro:200,300,400,700,900" rel="stylesheet" type="text/css">
 
     <link rel="stylesheet" type="text/css" href="css/base.css">
 </head>


### PR DESCRIPTION
This should fix the following warning in the browser: 

> Mixed Content: The page at 'https://moosehead.javazone.no/#/' was loaded over HTTPS, but requested an insecure stylesheet 'http://fonts.googleapis.com/css?family=Source+Sans+Pro:200,300,400,700,900'. This request has been blocked; the content must be served over HTTPS.

I tested it locally by running no.java.moosehead.web.WebServer from the IDE and it still works with http when I test locally. Please re-check if the warning is gone once the app has been redeployed.

After this change it will no longer work opening the HTML directly in the browser for development (if that is how development is done here). If this would be the case, consider hardcoding "https" as a prefix.

For more information on this: https://www.amixa.com/blog/2012/06/06/how-to-use-google-fonts-under-both-ssl-and-non-ssl-without-ssl-insecure-messages/